### PR TITLE
Add lower case glv to PATHS

### DIFF
--- a/cmake/modules/FindGLV.cmake
+++ b/cmake/modules/FindGLV.cmake
@@ -10,10 +10,10 @@
 
 if ((NOT GLV_INCLUDE_DIR) OR (NOT GLV_LIBRARY))
   FIND_PATH( GLV_INCLUDE_DIR GLV/glv.h
-    PATHS ../GLV/ ../../GLV/ ../../../GLV/
+    PATHS ../GLV/ ../../GLV/ ../../../GLV/ ../glv/ ../../glv ../../../glv
     DOC "The directory where GLV/glv.h resides")
   FIND_LIBRARY( GLV_LIBRARY
     NAMES GLV
-    PATHS ../GLV/build/lib/ ../../GLV/build/lib/ ../../../GLV/build/lib/  
+    PATHS ../GLV/build/lib/ ../../GLV/build/lib/ ../../../GLV/build/lib/  ../glv/build/lib/ ../../glv/build/lib/ ../../../glv/build/lib/
     DOC "The directory where libGLV resides")
 endif ((NOT GLV_INCLUDE_DIR) OR (NOT GLV_LIBRARY))


### PR DESCRIPTION
CMake 2.8.12.2 on Ubuntu 14.04 cannot find GLV paths with uppercase GLV
